### PR TITLE
Dev fix infodoc fluxo

### DIFF
--- a/src/main/webapp/app/config/notification-middleware.ts
+++ b/src/main/webapp/app/config/notification-middleware.ts
@@ -14,17 +14,17 @@ export default () => next => action => {
    */
   if (isFulfilledAction(action) && payload && payload.headers) {
     const headers = payload?.headers;
-    let alert: string | null = null;
+    let alert: string = '';
     headers &&
       Object.entries<string>(headers).forEach(([k, v]) => {
         if (k.toLowerCase().endsWith('app-alert')) {
           alert = v;
         }
       });
-    if (alert) {
-      // toast.success(alert);
-      console.info(alert);
+    if (alert && !alert.includes('all4QmsMsInfodocDocumentacao')) {
+      toast.success(alert);
     }
+    console.info(alert);
   }
 
   if (isRejectedAction(action) && error && error.isAxiosError) {

--- a/src/main/webapp/app/config/notification-middleware.ts
+++ b/src/main/webapp/app/config/notification-middleware.ts
@@ -22,7 +22,8 @@ export default () => next => action => {
         }
       });
     if (alert) {
-      toast.success(alert);
+      // toast.success(alert);
+      console.info(alert);
     }
   }
 

--- a/src/main/webapp/app/modules/infodoc/new/new-document.tsx
+++ b/src/main/webapp/app/modules/infodoc/new/new-document.tsx
@@ -476,7 +476,7 @@ export const NewDocument = () => {
             disabled
           />
 
-          <div className="mt-4">
+          {/* <div className="mt-4">
             <TextField
               id="text-field-keyword"
               label="Documentos relacionados"
@@ -493,7 +493,7 @@ export const NewDocument = () => {
             {keywordList.map((keyword: string, index: number) => (
               <Chip key={index} label={keyword} onDelete={event => onKeywordRemoved(event, index)} className="me-2" />
             ))}
-          </div>
+          </div> */}
 
           <div style={{ display: 'flex', justifyContent: 'flex-end', height: '45px' }} className="mt-5">
             <Button

--- a/src/main/webapp/app/modules/infodoc/ui/dialogs/cancel-document-dialog/cancel-document-dialog.tsx
+++ b/src/main/webapp/app/modules/infodoc/ui/dialogs/cancel-document-dialog/cancel-document-dialog.tsx
@@ -67,6 +67,7 @@ export const CancelDocumentDialog = ({ open, handleClose, documentTitle, infodoc
         }
 
         usersSGQ.map(user => sendPendenciasSGQ(user));
+        setJustifyValue('');
 
         handleClose();
       },

--- a/src/main/webapp/app/modules/infodoc/ui/dialogs/reject-document-dialog/reject-document-dialog.tsx
+++ b/src/main/webapp/app/modules/infodoc/ui/dialogs/reject-document-dialog/reject-document-dialog.tsx
@@ -59,6 +59,8 @@ export const RejectDocumentDialog = ({ open, handleClose, documentTitle, current
             motivoReprovacao: '',
           })
         );
+
+        setDescription('');
         navigate('/infodoc');
       })
       .catch(e => {

--- a/src/main/webapp/app/modules/infodoc/ui/dialogs/upload-dialog/upload-files.css
+++ b/src/main/webapp/app/modules/infodoc/ui/dialogs/upload-dialog/upload-files.css
@@ -28,6 +28,7 @@
 }
 
 .file-actions button {
+  /* height: 20px; */
   background-color: transparent;
   border: none;
   font-size: 20px;
@@ -65,9 +66,10 @@
 
 .file-info span {
   color: rgb(77, 77, 77);
+  /* background-color: #f30000; */
   padding-top: 10px;
   max-height: 150px;
-  width: 100%;
+  /* width: 100%; */
   font-size: 1vh;
   text-align: center;
   word-break: break-word; /* Quebra as palavras longas que ultrapassam o contêiner */
@@ -77,6 +79,8 @@
 }
 
 .file-info {
+  width: 400px;
+  /* background-color: #ebc139; */
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/main/webapp/app/modules/infodoc/ui/home/infodoc-list.tsx
+++ b/src/main/webapp/app/modules/infodoc/ui/home/infodoc-list.tsx
@@ -493,7 +493,7 @@ const InfodocList = () => {
               </TableHead>
               <TableBody>
                 {infodocs?.map((infodoc: InfoDoc) => (
-                  <TableRow key={infodoc.doc.id}>
+                  <TableRow key={infodoc.doc.id} style={{ cursor: infodoc.doc.enumSituacao !== 'H' ? 'pointer' : 'auto' }}>
                     <Tooltip title={infodoc.doc.descricaoDoc}>
                       <TableCell>{infodoc.doc.codigo}</TableCell>
                     </Tooltip>

--- a/src/main/webapp/app/modules/infodoc/update/update-document.tsx
+++ b/src/main/webapp/app/modules/infodoc/update/update-document.tsx
@@ -474,7 +474,7 @@ export const UpdateDocument = () => {
             onChange={e => setDocumentDescription(e.target.value)}
           />
 
-          <div className="mt-4">
+          {/* <div className="mt-4">
             <TextField
               id="text-field-keyword"
               label="Escreva aqui..."
@@ -491,7 +491,7 @@ export const UpdateDocument = () => {
             {keywordList.map((keyword: string, index: number) => (
               <Chip label={keyword} onDelete={event => onKeywordRemoved(event, index)} className="me-2" />
             ))}
-          </div>
+          </div> */}
 
           <div style={{ display: 'flex', justifyContent: 'flex-end', height: '45px' }} className="mt-5">
             <Button variant="contained" className="me-3" style={{ background: '#d9d9d9', color: '#4e4d4d' }} onClick={() => cancelUpdate()}>

--- a/src/main/webapp/app/modules/infodoc/validation-infodoc/validation-document.tsx
+++ b/src/main/webapp/app/modules/infodoc/validation-infodoc/validation-document.tsx
@@ -210,6 +210,9 @@ export const ValidationDocument = () => {
   };
   const handleGetResume = async () => {
     try {
+      if (!fileUploaded) {
+        toast.warn('Não foi encontrado nem um documento revisado anexado, anexe-o antes e tente novamente.');
+      }
       setLoadingIA(true);
       const resToken = await dispatch(getTokenResumeIA(fileUploaded));
       const tokenResumeIA = (resToken.payload as AxiosResponse).data;
@@ -242,6 +245,7 @@ export const ValidationDocument = () => {
           var fileDownload = require('js-file-download');
           let fileName = result.headers['content-disposition'].split(';')[1];
           fileName = fileName.split('=')[1];
+          fileName = fileName.split('_').pop()!!;
 
           const file = new Blob([result.data], { type: 'application/octet-stream' });
 
@@ -555,7 +559,7 @@ export const ValidationDocument = () => {
                 label="Notificar antes de:"
                 value={notificationPreviousDate}
                 onChange={event => setNotificationPreviousDate(event.target.value)}
-                disabled={!isSGQ}
+                disabled={!isSGQ || (isSGQ && noValidate)}
               >
                 <MenuItem value="0">Não notificar</MenuItem>
                 <MenuItem value="15d">15 dias antes</MenuItem>
@@ -614,7 +618,7 @@ export const ValidationDocument = () => {
             </Button>
             <Button
               className="ms-3"
-              disabled={!validateFields()}
+              // disabled={!validateFields()}
               onClick={() => saveDocument()}
               sx={{ border: validateFields() ? '1px solid #000' : '', color: '#000', width: '100px' }}
             >

--- a/src/main/webapp/app/modules/infodoc/validation-infodoc/validation-document.tsx
+++ b/src/main/webapp/app/modules/infodoc/validation-infodoc/validation-document.tsx
@@ -589,7 +589,7 @@ export const ValidationDocument = () => {
             onChange={e => setDocumentDescription(e.target.value)}
           />
 
-          <div className="mt-4">
+          {/* <div className="mt-4">
             <TextField
               id="text-field-keyword"
               label="Escreva aqui..."
@@ -606,7 +606,7 @@ export const ValidationDocument = () => {
             {keywordList.map((keyword: string, index: number) => (
               <Chip label={keyword} onDelete={event => onKeywordRemoved(event, index)} className="me-2" />
             ))}
-          </div>
+          </div> */}
 
           <div style={{ display: 'flex', justifyContent: 'flex-end', height: '45px' }} className="mt-5">
             <Button


### PR DESCRIPTION
Ajustes:
 - arquivo baixado um título diferente ao que foi adicionado;
 - Botão de encaminhar os “dados dos documentos” bloqueado;
 - Falta de localização das mensagens pop-up [Comportamento padrão do JHipste];
 - Texto de motivo permanece em cache; 
 - Mudança do cursor;
 - Inativação dos campos de validade;
 - Falta de resposta do botão da I.A;
 - Impedindo salvamento sem preenchimento dos campos obrigatórios;